### PR TITLE
Wrong italian translation

### DIFF
--- a/1.7/translations/1.7.6/it-IT/ShopNotificationsError.it-IT.xlf
+++ b/1.7/translations/1.7.6/it-IT/ShopNotificationsError.it-IT.xlf
@@ -381,7 +381,7 @@
     <body>
       <trans-unit id="15ef0f1f63c1e8a9fb8abad024939262" approved="yes">
         <source>You have no merchandise return authorizations.</source>
-        <target state="final">Non hai le autorizzazioni per la resa di merce.</target>
+        <target state="final">Non hai autorizzazioni per la restituzione della merce.</target>
         <note>Line: 103</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
ENG: You have no merchandise return authorizations.
ITA:  Non hai autorizzazioni per la restituzione della merce.

