### PR TITLE
Fix backoffice "unexpected token" error with Spanish language

### DIFF
--- a/1.7/translations/1.7.8/es-ES/AdminModulesNotification.es-ES.xlf
+++ b/1.7/translations/1.7.8/es-ES/AdminModulesNotification.es-ES.xlf
@@ -878,8 +878,7 @@ Comment: Confirm uninstall</note>
       </trans-unit>
       <trans-unit id="8f7168b76e182d2c1dd8769fa23fbdbd" approved="yes">
         <source>We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues.</source>
-        <target state="final">Le recomendamos encarecidamente que actualice los módulos en modo de mantenimiento para evitar problemas de caché. 
-</target>
+        <target state="final">Le recomendamos encarecidamente que actualice los módulos en modo de mantenimiento para evitar problemas de caché.</target>
         <note>Line: 45</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Addon installation is broken when the BO is in Spanish due an unexpected token error caused by a new line character.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26028
| How to test?      | Change language to Spanish (Spain) and try to upload a module.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
