### PR TITLE
Use -core-oss in bucket name

### DIFF
--- a/.github/workflows/push_archives_to_bucket.yml
+++ b/.github/workflows/push_archives_to_bucket.yml
@@ -88,5 +88,5 @@ jobs:
               run: php bin/console prestashop:bucket:push-archives --prestashop-version=${{ inputs.prestashop_version }}
               env:
                   TRANSLATIONS_GCP_PROJECT_ID: core-oss-${{ inputs.environment }}
-                  TRANSLATIONS_GCP_BUCKET_NAME: translations-${{ inputs.environment }}
+                  TRANSLATIONS_GCP_BUCKET_NAME: translations-core-oss-${{ inputs.environment }}
                   TRANSLATIONS_GCP_CREDENTIAL_FILE: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}


### PR DESCRIPTION
As translations-production already existed, we change all bucket names to translations-core-oss-{{environment}}