### PR TITLE
Add version 9 in the list of version to handle

### DIFF
--- a/.github/workflows/automatic_push_archives_to_bucket.yml
+++ b/.github/workflows/automatic_push_archives_to_bucket.yml
@@ -38,6 +38,7 @@ jobs:
             fail-fast: false
             matrix:
                 prestashop_version:
+                    - '9.0.x'
                     - '8.0.x'
                     - '1.7.8.x'
         uses: PrestaShop/TranslationFiles/.github/workflows/push_archives_to_bucket.yml@master

--- a/.github/workflows/manual_push_archives_to_bucket.yml
+++ b/.github/workflows/manual_push_archives_to_bucket.yml
@@ -8,9 +8,10 @@ on:
             prestashop_version:
                 description: Which PrestaShop version you want to update
                 required: true
-                default: '8.0'
+                default: '8.0.x'
                 type: choice
                 options:
+                    - '9.0.x'
                     - '8.0.x'
                     - '1.7.8.x'
             environment:

--- a/.github/workflows/push_archives_to_bucket.yml
+++ b/.github/workflows/push_archives_to_bucket.yml
@@ -35,7 +35,7 @@ jobs:
               run: |
                if test ${{ inputs.environment }} = "production";
                then
-                 echo "TRANSLATION_TOOL_REF=2.0.1" >> $GITHUB_OUTPUT
+                 echo "TRANSLATION_TOOL_REF=2.0.2" >> $GITHUB_OUTPUT
                  echo "TRANSLATION_FILES_BRANCH=master" >> $GITHUB_OUTPUT
                elif test ${{ inputs.environment }} = "preproduction";
                then
@@ -62,7 +62,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.1'
                   extensions: curl, json
 
             - name: Install composer dependencies


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add version 9 in the list of version to handle in TranslationFiles automatic update, the next step will be to create the initial folder for version 9 from this PR https://github.com/PrestaShop/TranslationFiles/pull/36 Since the workflow will have been updated already it will automatically update the bucket, create the new folder for version 9 thus making the API accessible for future version 9
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | ~
